### PR TITLE
feat(flow2src): add support for Node-RED Dashboard v2 ui-template node

### DIFF
--- a/flow2src/flow2src.js
+++ b/flow2src/flow2src.js
@@ -120,7 +120,7 @@ module.exports = function(RED) {
                             idMap[obj.id] = { folder: obj.name.replace(/[^a-z0-9]/gi, '_'), subflow: true };
                         }
                         // Gather nodes and templates
-                        if (obj.type == 'template' || obj.type == 'function' || obj.type == 'wp function') {
+                        if (obj.type == 'template' || obj.type == 'ui-template' || obj.type == 'function' || obj.type == 'wp function') {
                             theNodes.push(obj);
                         }
                     });
@@ -145,6 +145,9 @@ module.exports = function(RED) {
                             if (ext != '') {
                                 ext = '.' + ext;
                             }
+                        }
+                        if (obj.type == 'ui-template') {
+                            ext = '.html';
                         }
                         if (obj.type == 'function') {
                             ext = '.js';
@@ -178,6 +181,13 @@ module.exports = function(RED) {
                                 property: 'template',
                                 file: file,
                                 subflow: info.subflow
+                            });
+                            existingFiles.push(file);
+                        } else if (obj.type == 'ui-template') {
+                            obj.srcFiles.push({
+                                id: obj.id,
+                                property: 'format',
+                                file: file
                             });
                             existingFiles.push(file);
                         } else if (obj.type == 'function') {


### PR DESCRIPTION
This PR adds support for the Node-RED Dashboard v2 ui-template node in flow2src.

Motivation:
- Dashboard v2 uses a different ui-template structure
- flow2src previously ignored these nodes

Changes:
- Extended node detection for dashboard v2
- Added handling for ui-template config

Tested with:
- Node-RED 4.1.9 and Dashboard V2